### PR TITLE
Feature/sand trap manager

### DIFF
--- a/Assets/Prefabs/SandTrapManager.prefab
+++ b/Assets/Prefabs/SandTrapManager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4750035227496251320
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4750035227496251326}
+  - component: {fileID: 4750035227496251321}
+  m_Layer: 0
+  m_Name: SandTrapManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4750035227496251326
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4750035227496251320}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.34100878, y: -1.2916399, z: 1.8961984}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4750035227496251321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4750035227496251320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6415b5debd168aacba97475513a9357c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SandTrapList: []

--- a/Assets/Prefabs/SandTrapManager.prefab.meta
+++ b/Assets/Prefabs/SandTrapManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a471ea77c515e223eb6cfea145025dda
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/sand trap test.unity
+++ b/Assets/Scenes/sand trap test.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657868, g: 0.49641263, b: 0.57481706, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -627,3 +627,72 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1001 &4750035226741757666
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4750035227496251320, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_Name
+      value: SandTrapManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.34100878
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.2916399
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.8961984
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a471ea77c515e223eb6cfea145025dda, type: 3}

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -6,7 +6,20 @@ using UnityEngine.SceneManagement;
 public class SandTrapManager : MonoBehaviour
 {
 
+    public static SandTrapManager instance = null;
     public List<GameObject> SandTrapList = new List<GameObject>();
+
+    void Awake() {
+        if (instance == null) {
+            instance = this;
+        }
+
+        else if (instance != this) {
+            Destroy(gameObject);
+        }
+        DontDestroyOnLoad(gameObject);
+    }
+
 
     public void FindSandTrapsInTheScene() {
         foreach(GameObject GameObjectInTheScene in GameObject.FindObjectsOfType(typeof(GameObject)))

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class SandTrapManager : MonoBehaviour
+{
+
+    public List<GameObject> SandTrapList = new List<GameObject>();
+
+    public void FindSandTrapsInTheScene() {
+        foreach(GameObject GameObjectInTheScene in GameObject.FindObjectsOfType(typeof(GameObject)))
+         {
+             if(GameObjectInTheScene.GetComponent<SandTrap>() != null)
+             SandTrapList.Add (GameObjectInTheScene);
+         }  
+
+    }       
+
+}

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -3,22 +3,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-public class SandTrapManager : MonoBehaviour
-{
+public class SandTrapManager : Singleton<SandTrapManager> {
 
-    public static SandTrapManager instance = null;
     public List<GameObject> SandTrapList = new List<GameObject>();
-
-    void Awake() {
-        if (instance == null) {
-            instance = this;
-        }
-
-        else if (instance != this) {
-            Destroy(gameObject);
-        }
-        DontDestroyOnLoad(gameObject);
-    }
 
 
     public void FindSandTrapsInTheScene() {

--- a/Assets/Scripts/SandTrapManager.cs.meta
+++ b/Assets/Scripts/SandTrapManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6415b5debd168aacba97475513a9357c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Singleton.cs
+++ b/Assets/Scripts/Singleton.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class Singleton<T> : MonoBehaviour where T: MonoBehaviour {
+    public static T Instance {
+        get {
+            InitializeIfNecessary();
+            return _instance;
+        }
+    }
+    static T _instance;
+
+    static void InitializeIfNecessary () {
+        if (_instance == null) {
+            _instance = Object.FindObjectOfType<T>();
+        }
+    }
+
+    void Awake () {
+        if (_instance != null && _instance != this) {
+            Destroy(this);
+            return;
+        }
+        InitializeIfNecessary();
+    }
+
+    void OnDestroy () {
+        _instance = null;
+    }
+}

--- a/Assets/Scripts/Singleton.cs.meta
+++ b/Assets/Scripts/Singleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf993ef975e1406dfb9a546b53166638
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Sand Trap Manager añadido!

https://trello.com/c/cNp5vSKC
https://trello.com/c/HrnhDPQw

### What's New

Se ha creado un Sand Trap Manager que al ejecutarse detecta a todos las trampas de arena en la escena.

### Known Problems

El Sand Trap Manager solo funciona cuando el juego se está ejecutando, hay que arreglarlo para que funcione en el inspector en tiempo de edición

### Testing

Entrar a una escena con trampas de arena y correr el juego, luego, seleccionar al Sand Trap Manager y ver como funciona.

### Setting Up

Hacer el set up básico de un nivel y añadir el Prefab "SandTrap" y añadir el Sand Trap Manager.