### PR TITLE
Feature/sand trap editor

### DIFF
--- a/Assets/Prefabs/SandTrapManager.prefab
+++ b/Assets/Prefabs/SandTrapManager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4750035227496251320
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4750035227496251326}
+  - component: {fileID: 4750035227496251321}
+  m_Layer: 0
+  m_Name: SandTrapManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4750035227496251326
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4750035227496251320}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.34100878, y: -1.2916399, z: 1.8961984}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4750035227496251321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4750035227496251320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6415b5debd168aacba97475513a9357c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SandTrapList: []

--- a/Assets/Prefabs/SandTrapManager.prefab.meta
+++ b/Assets/Prefabs/SandTrapManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a471ea77c515e223eb6cfea145025dda
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/sand trap test.unity
+++ b/Assets/Scenes/sand trap test.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657868, g: 0.49641263, b: 0.57481706, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -627,3 +627,72 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1001 &4750035226741757666
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4750035227496251320, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_Name
+      value: SandTrapManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.34100878
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.2916399
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.8961984
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a471ea77c515e223eb6cfea145025dda, type: 3}

--- a/Assets/Scenes/sand trap test.unity
+++ b/Assets/Scenes/sand trap test.unity
@@ -162,7 +162,7 @@ PrefabInstance:
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
@@ -267,7 +267,7 @@ PrefabInstance:
     - target: {fileID: 759865170314520294, guid: 9e7a176d2dc294f9ba9a2d41ae51b557,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 759865170314520294, guid: 9e7a176d2dc294f9ba9a2d41ae51b557,
         type: 3}
@@ -351,7 +351,7 @@ PrefabInstance:
     - target: {fileID: 3089192009489218320, guid: 11f913f272570475da546d44e48a179c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3089192009489218320, guid: 11f913f272570475da546d44e48a179c,
         type: 3}
@@ -435,7 +435,7 @@ PrefabInstance:
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
@@ -519,7 +519,7 @@ PrefabInstance:
     - target: {fileID: 759865170314520294, guid: 9e7a176d2dc294f9ba9a2d41ae51b557,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 759865170314520294, guid: 9e7a176d2dc294f9ba9a2d41ae51b557,
         type: 3}
@@ -543,7 +543,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9e7a176d2dc294f9ba9a2d41ae51b557, type: 3}
---- !u!1001 &3694137321512415996
+--- !u!1001 &827152296
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -553,12 +553,12 @@ PrefabInstance:
     - target: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_Name
-      value: SandTrap
+      value: SandTrap (3)
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.36
+      value: -4.27
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
@@ -568,7 +568,7 @@ PrefabInstance:
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.41
+      value: -4.28
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
@@ -593,7 +593,259 @@ PrefabInstance:
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: rb
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: sphere
+      value: 
+      objectReference: {fileID: 170597322}
+    - target: {fileID: 3694137320299519850, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1001 &1425244307
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_Name
+      value: SandTrap (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.26
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: rb
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: sphere
+      value: 
+      objectReference: {fileID: 170597322}
+    - target: {fileID: 3694137320299519850, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1001 &1443126672
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_Name
+      value: SandTrap (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.8661857
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.429804
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: rb
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: sphere
+      value: 
+      objectReference: {fileID: 170597322}
+    - target: {fileID: 3694137320299519850, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1001 &3694137321512415996
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_Name
+      value: SandTrap
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.5462017
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.820839
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
@@ -642,17 +894,17 @@ PrefabInstance:
     - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.34100878
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.2916399
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.8961984
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
         type: 3}
@@ -677,7 +929,7 @@ PrefabInstance:
     - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
         type: 3}

--- a/Assets/Scenes/sand trap test.unity
+++ b/Assets/Scenes/sand trap test.unity
@@ -211,6 +211,68 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1 &146322190
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 146322193}
+  - component: {fileID: 146322192}
+  - component: {fileID: 146322191}
+  m_Layer: 0
+  m_Name: SandTrap(Clone)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &146322191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146322190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8ca8351ec98c0a4380da2c166f8a9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!54 &146322192
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146322190}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!4 &146322193
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146322190}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.1740124, y: 1.0957024, z: -3.795393}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 426142881}
+  - {fileID: 639487423}
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &170597322 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3089192009192382083, guid: 11f913f272570475da546d44e48a179c,
@@ -391,12 +453,254 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 11f913f272570475da546d44e48a179c, type: 3}
+--- !u!1 &426142880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 426142881}
+  - component: {fileID: 426142883}
+  - component: {fileID: 426142882}
+  m_Layer: 0
+  m_Name: Model
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &426142881
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 426142880}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.04, z: 0}
+  m_LocalScale: {x: 1, y: 0.06, z: 1}
+  m_Children: []
+  m_Father: {fileID: 146322193}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &426142882
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 426142880}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e59884a161fd1ca4790241b5f1e498fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &426142883
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 426142880}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &527169766 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
     type: 3}
   m_PrefabInstance: {fileID: 1443126672}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &620278717
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 620278718}
+  - component: {fileID: 620278720}
+  - component: {fileID: 620278719}
+  m_Layer: 0
+  m_Name: Model
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &620278718
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620278717}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.04, z: 0}
+  m_LocalScale: {x: 1, y: 0.06, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1092866635}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &620278719
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620278717}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e59884a161fd1ca4790241b5f1e498fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &620278720
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620278717}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &625871051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 625871052}
+  - component: {fileID: 625871053}
+  m_Layer: 0
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &625871052
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625871051}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1092866635}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &625871053
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625871051}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 1, z: 0.6}
+  m_Center: {x: 0, y: 0.5, z: 0}
+--- !u!1 &639487422
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 639487423}
+  - component: {fileID: 639487424}
+  m_Layer: 0
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &639487423
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 639487422}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 146322193}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &639487424
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 639487422}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 1, z: 0.6}
+  m_Center: {x: 0, y: 0.5, z: 0}
 --- !u!1001 &699514398
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -477,6 +781,68 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 82140991}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1092866632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1092866635}
+  - component: {fileID: 1092866634}
+  - component: {fileID: 1092866633}
+  m_Layer: 0
+  m_Name: SandTrap(Clone)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1092866633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092866632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8ca8351ec98c0a4380da2c166f8a9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!54 &1092866634
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092866632}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!4 &1092866635
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092866632}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.2645245, y: 1.0957024, z: 0.6290364}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 620278718}
+  - {fileID: 625871052}
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1443126672
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -561,6 +927,189 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1 &1494374178
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1494374181}
+  - component: {fileID: 1494374180}
+  - component: {fileID: 1494374179}
+  m_Layer: 0
+  m_Name: SandTrap(Clone)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1494374179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494374178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8ca8351ec98c0a4380da2c166f8a9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!54 &1494374180
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494374178}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!4 &1494374181
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494374178}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.561784, y: 1.0957024, z: 7.919606}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1901611551}
+  - {fileID: 2065168483}
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1901611550
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1901611551}
+  - component: {fileID: 1901611553}
+  - component: {fileID: 1901611552}
+  m_Layer: 0
+  m_Name: Model
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1901611551
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1901611550}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.04, z: 0}
+  m_LocalScale: {x: 1, y: 0.06, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1494374181}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1901611552
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1901611550}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e59884a161fd1ca4790241b5f1e498fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1901611553
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1901611550}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2065168482
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2065168483}
+  - component: {fileID: 2065168484}
+  m_Layer: 0
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2065168483
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2065168482}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1494374181}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2065168484
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2065168482}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 1, z: 0.6}
+  m_Center: {x: 0, y: 0.5, z: 0}
 --- !u!1001 &3694137321512415996
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/sand trap test.unity
+++ b/Assets/Scenes/sand trap test.unity
@@ -137,7 +137,7 @@ PrefabInstance:
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 8.85
+      value: -1.92
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
@@ -301,6 +301,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9e7a176d2dc294f9ba9a2d41ae51b557, type: 3}
+--- !u!1 &332444197 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+    type: 3}
+  m_PrefabInstance: {fileID: 3694137321512415996}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &414390772
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -385,90 +391,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 11f913f272570475da546d44e48a179c, type: 3}
---- !u!1001 &482878788
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_Name
-      value: SandTrap (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -4.28
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: rb
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: sphere
-      value: 
-      objectReference: {fileID: 170597322}
-    - target: {fileID: 3694137320299519850, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_IsTrigger
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1 &527169766 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+    type: 3}
+  m_PrefabInstance: {fileID: 1443126672}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &699514398
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -543,174 +471,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9e7a176d2dc294f9ba9a2d41ae51b557, type: 3}
---- !u!1001 &827152296
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_Name
-      value: SandTrap (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -4.28
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: rb
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: sphere
-      value: 
-      objectReference: {fileID: 170597322}
-    - target: {fileID: 3694137320299519850, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_IsTrigger
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
---- !u!1001 &1425244307
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_Name
-      value: SandTrap (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.26
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: rb
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3694137321633398237, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: sphere
-      value: 
-      objectReference: {fileID: 170597322}
-    - target: {fileID: 3694137320299519850, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
-        type: 3}
-      propertyPath: m_IsTrigger
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b0489998c43dc4430bcb8f0dcfa4cafc, type: 3}
+--- !u!1 &880433615 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+    type: 3}
+  m_PrefabInstance: {fileID: 82140991}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1443126672
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -761,7 +527,7 @@ PrefabInstance:
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
@@ -845,7 +611,7 @@ PrefabInstance:
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3694137321633398239, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
         type: 3}
@@ -929,7 +695,7 @@ PrefabInstance:
     - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4750035227496251326, guid: a471ea77c515e223eb6cfea145025dda,
         type: 3}
@@ -945,6 +711,52 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: SandTrapList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: TrapPrefab
+      value: 
+      objectReference: {fileID: 3694137321633398236, guid: b0489998c43dc4430bcb8f0dcfa4cafc,
+        type: 3}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: SandTrapList.Array.data[0]
+      value: 
+      objectReference: {fileID: 332444197}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: SandTrapList.Array.data[1]
+      value: 
+      objectReference: {fileID: 527169766}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: SandTrapList.Array.data[2]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: SandTrapList.Array.data[3]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: SandTrapList.Array.data[4]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: SandTrapList.Array.data[5]
+      value: 
+      objectReference: {fileID: 880433615}
+    - target: {fileID: 4750035227496251321, guid: a471ea77c515e223eb6cfea145025dda,
+        type: 3}
+      propertyPath: hitPoint
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a471ea77c515e223eb6cfea145025dda, type: 3}

--- a/Assets/Scripts/Editor/SandTrapManagerEditor.cs
+++ b/Assets/Scripts/Editor/SandTrapManagerEditor.cs
@@ -1,0 +1,43 @@
+﻿using UnityEngine;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using System.Collections;
+using System.Collections.Generic;
+
+[CustomEditor(typeof(SandTrapManager))]
+public class SandTrapManagerEditor : Editor {
+    SandTrapManager Target { get => (SandTrapManager) target; }
+
+void OnEnable() {
+    Target.FindSandTraps();
+    }
+void OnDisable() {
+    Target.ClearList();
+}
+
+public override void OnInspectorGUI() {
+    DrawDefaultInspector();
+
+/*    bool wasPressed = GUILayout.Button("CLEAR");
+    if (wasPressed) {
+        Target.ClearList();
+    }
+*/
+
+}
+
+void OnSceneGUI() {
+        
+    if (Target.SandTrapList == null || Target.SandTrapList.Count == 0) return;
+
+    foreach (GameObject trap in Target.SandTrapList) {
+        bool ButtonOnSandTraps =
+                Handles.Button(trap.transform.position
+                + trap.transform.forward * 0.5f
+                + trap.transform.right * 0.5f,
+                Quaternion.Euler(90,0,0),
+                0.25f, 0.25f,
+                Handles.RectangleHandleCap); 
+        }
+    }
+}

--- a/Assets/Scripts/Editor/SandTrapManagerEditor.cs
+++ b/Assets/Scripts/Editor/SandTrapManagerEditor.cs
@@ -4,40 +4,78 @@ using UnityEditor.SceneManagement;
 using System.Collections;
 using System.Collections.Generic;
 
-[CustomEditor(typeof(SandTrapManager))]
+[CustomEditor(typeof(SandTrapManager)), CanEditMultipleObjects]
 public class SandTrapManagerEditor : Editor {
     SandTrapManager Target { get => (SandTrapManager) target; }
 
 void OnEnable() {
     Target.FindSandTraps();
+    Undo.undoRedoPerformed += FixtheList;
     }
+
 void OnDisable() {
     Target.ClearList();
 }
 
 public override void OnInspectorGUI() {
     DrawDefaultInspector();
+    bool MoveSandTrap = GUILayout.Button("Move traps");
+    
 
-/*    bool wasPressed = GUILayout.Button("CLEAR");
-    if (wasPressed) {
-        Target.ClearList();
+    if (MoveSandTrap) {
+
+
+
     }
-*/
-
 }
+
 
 void OnSceneGUI() {
         
     if (Target.SandTrapList == null || Target.SandTrapList.Count == 0) return;
 
     foreach (GameObject trap in Target.SandTrapList) {
-        bool ButtonOnSandTraps =
+        bool PresstheButton =
                 Handles.Button(trap.transform.position
                 + trap.transform.forward * 0.5f
                 + trap.transform.right * 0.5f,
                 Quaternion.Euler(90,0,0),
-                0.25f, 0.25f,
+                0.5f, 0.5f,
                 Handles.RectangleHandleCap); 
+
+        DrawGizmos(trap);
+
+
+        if (PresstheButton) {
+
+            Undo.RecordObject(Target, "Sand trap destroyed");
+            Target.SandTrapList.Remove(trap);
+            Undo.DestroyObjectImmediate(trap);
+            break;
+
+            }
         }
     }
+
+void DrawGizmos(GameObject trap) {
+
+    EditorGUI.BeginChangeCheck();
+    Vector3 newTargetPosition = Handles.PositionHandle(trap.transform.position, Quaternion.identity);
+    if (EditorGUI.EndChangeCheck()) {
+
+        Undo.RecordObject(trap, "A trap was moved");
+        trap.transform.position = newTargetPosition;
+
+    }
+
+
+}
+
+void FixtheList() {
+
+    Target.ClearList();
+    Target.FindSandTraps();
+
+    }
+
 }

--- a/Assets/Scripts/Editor/SandTrapManagerEditor.cs
+++ b/Assets/Scripts/Editor/SandTrapManagerEditor.cs
@@ -14,7 +14,7 @@ public static bool DeleteSandTrap;
     SandTrapManager Target { get => (SandTrapManager) target; }
 
 void OnEnable() {
-    Target.FindSandTraps();
+    FixtheList();
     Undo.undoRedoPerformed += FixtheList;
     }
 
@@ -33,7 +33,7 @@ public override void OnInspectorGUI() {
     }
 
     if (CreateSandTrap) {
-
+        SceneView.RepaintAll();
     }
 
     if (DeleteSandTrap) {
@@ -49,7 +49,11 @@ void OnSceneGUI() {
     
     if (DeleteSandTrap) {
         DrawDeleteSquares();
-    } 
+    }
+
+    if (CreateSandTrap) {
+        EnableCreateMode();
+    }
 
     if (MoveSandTrap) {
         DrawGizmos();
@@ -71,6 +75,14 @@ void DrawGizmos() {
             }
         }
     }
+
+void EnableCreateMode () {
+
+
+
+    FixtheList();
+}
+
 
 void DrawDeleteSquares() {
     foreach (GameObject trap in Target.SandTrapList) {

--- a/Assets/Scripts/Editor/SandTrapManagerEditor.cs
+++ b/Assets/Scripts/Editor/SandTrapManagerEditor.cs
@@ -64,8 +64,10 @@ void DrawGizmos() {
         Vector3 newTargetPosition = Handles.PositionHandle(trap.transform.position, Quaternion.identity);
         
         if (EditorGUI.EndChangeCheck()) {
-            Undo.RecordObject(trap, "A trap was moved");
+            
+            Undo.RecordObject(trap.transform, "A trap was moved");
             trap.transform.position = newTargetPosition;
+            
             }
         }
     }

--- a/Assets/Scripts/Editor/SandTrapManagerEditor.cs
+++ b/Assets/Scripts/Editor/SandTrapManagerEditor.cs
@@ -78,6 +78,22 @@ void DrawGizmos() {
 
 void EnableCreateMode () {
 
+Ray rayo = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
+        RaycastHit hit;
+
+        bool didHit = Physics.Raycast(rayo, out hit);
+        bool isClicking =
+            Event.current.type == EventType.MouseDown &&
+            Event.current.button == 0;
+
+        if (didHit && isClicking) {
+            GUIUtility.hotControl = GUIUtility.GetControlID(FocusType.Passive);
+            Event.current.Use();
+            GameObject newTrap = Instantiate(Target.TrapPrefab);
+            newTrap.transform.position = hit.point;
+
+            Undo.RegisterCreatedObjectUndo(newTrap, "Game object created");
+        }
 
 
     FixtheList();

--- a/Assets/Scripts/Editor/SandTrapManagerEditor.cs
+++ b/Assets/Scripts/Editor/SandTrapManagerEditor.cs
@@ -6,6 +6,11 @@ using System.Collections.Generic;
 
 [CustomEditor(typeof(SandTrapManager)), CanEditMultipleObjects]
 public class SandTrapManagerEditor : Editor {
+
+public static bool MoveSandTrap;
+public static bool CreateSandTrap;
+public static bool DeleteSandTrap;
+
     SandTrapManager Target { get => (SandTrapManager) target; }
 
 void OnEnable() {
@@ -19,33 +24,62 @@ void OnDisable() {
 
 public override void OnInspectorGUI() {
     DrawDefaultInspector();
-    bool MoveSandTrap = GUILayout.Button("Move traps");
-    
+    MoveSandTrap = GUILayout.Toggle(MoveSandTrap, "Move traps", "Button");
+    CreateSandTrap = GUILayout.Toggle(CreateSandTrap, "Create traps", "Button");
+    DeleteSandTrap = GUILayout.Toggle(DeleteSandTrap, "Delete traps", "Button");
 
     if (MoveSandTrap) {
+        SceneView.RepaintAll();
+    }
 
-
+    if (CreateSandTrap) {
 
     }
+
+    if (DeleteSandTrap) {
+        SceneView.RepaintAll();
+    }
+
 }
 
 
 void OnSceneGUI() {
         
     if (Target.SandTrapList == null || Target.SandTrapList.Count == 0) return;
+    
+    if (DeleteSandTrap) {
+        DrawDeleteSquares();
+    } 
+
+    if (MoveSandTrap) {
+        DrawGizmos();
+    }
+    
+}
+
+void DrawGizmos() {
 
     foreach (GameObject trap in Target.SandTrapList) {
-        bool PresstheButton =
-                Handles.Button(trap.transform.position
+        EditorGUI.BeginChangeCheck();
+        Vector3 newTargetPosition = Handles.PositionHandle(trap.transform.position, Quaternion.identity);
+        
+        if (EditorGUI.EndChangeCheck()) {
+            Undo.RecordObject(trap, "A trap was moved");
+            trap.transform.position = newTargetPosition;
+            }
+        }
+    }
+
+void DrawDeleteSquares() {
+    foreach (GameObject trap in Target.SandTrapList) {
+      bool PresstheButton =
+            Handles.Button(trap.transform.position
                 + trap.transform.forward * 0.5f
                 + trap.transform.right * 0.5f,
                 Quaternion.Euler(90,0,0),
                 0.5f, 0.5f,
-                Handles.RectangleHandleCap); 
-
-        DrawGizmos(trap);
-
-
+                Handles.RectangleHandleCap);
+        
         if (PresstheButton) {
 
             Undo.RecordObject(Target, "Sand trap destroyed");
@@ -54,28 +88,11 @@ void OnSceneGUI() {
             break;
 
             }
-        }
     }
-
-void DrawGizmos(GameObject trap) {
-
-    EditorGUI.BeginChangeCheck();
-    Vector3 newTargetPosition = Handles.PositionHandle(trap.transform.position, Quaternion.identity);
-    if (EditorGUI.EndChangeCheck()) {
-
-        Undo.RecordObject(trap, "A trap was moved");
-        trap.transform.position = newTargetPosition;
-
-    }
-
-
 }
-
 void FixtheList() {
 
     Target.ClearList();
     Target.FindSandTraps();
-
-    }
-
+        }
 }

--- a/Assets/Scripts/Editor/SandTrapManagerEditor.cs.meta
+++ b/Assets/Scripts/Editor/SandTrapManagerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 028660de0d044c1c785e8f738e1fe3a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -6,7 +6,20 @@ using UnityEngine.SceneManagement;
 public class SandTrapManager : MonoBehaviour
 {
 
+    public static SandTrapManager instance = null;
     public List<GameObject> SandTrapList = new List<GameObject>();
+
+    void Awake() {
+        if (instance == null) {
+            instance = this;
+        }
+
+        else if (instance != this) {
+            Destroy(gameObject);
+        }
+        DontDestroyOnLoad(gameObject);
+    }
+
 
     public void FindSandTrapsInTheScene() {
         foreach(GameObject GameObjectInTheScene in GameObject.FindObjectsOfType(typeof(GameObject)))

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class SandTrapManager : MonoBehaviour
+{
+
+    public List<GameObject> SandTrapList = new List<GameObject>();
+
+    public void FindSandTrapsInTheScene() {
+        foreach(GameObject GameObjectInTheScene in GameObject.FindObjectsOfType(typeof(GameObject)))
+         {
+             if(GameObjectInTheScene.GetComponent<SandTrap>() != null)
+             SandTrapList.Add (GameObjectInTheScene);
+         }  
+
+    }       
+
+}

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -3,22 +3,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-public class SandTrapManager : MonoBehaviour
-{
+public class SandTrapManager : Singleton<SandTrapManager> {
 
-    public static SandTrapManager instance = null;
     public List<GameObject> SandTrapList = new List<GameObject>();
-
-    void Awake() {
-        if (instance == null) {
-            instance = this;
-        }
-
-        else if (instance != this) {
-            Destroy(gameObject);
-        }
-        DontDestroyOnLoad(gameObject);
-    }
 
 
     public void FindSandTrapsInTheScene() {

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -5,6 +5,7 @@ using UnityEngine.SceneManagement;
 
 public class SandTrapManager : Singleton<SandTrapManager> {
 
+    public GameObject TrapPrefab;
     public List<GameObject> SandTrapList = new List<GameObject>();
 
 

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -18,6 +18,6 @@ public class SandTrapManager : Singleton<SandTrapManager> {
     }
     public void ClearList() {
         SandTrapList.Clear();
-    }       
+    }
 
 }

--- a/Assets/Scripts/SandTrapManager.cs
+++ b/Assets/Scripts/SandTrapManager.cs
@@ -8,13 +8,16 @@ public class SandTrapManager : Singleton<SandTrapManager> {
     public List<GameObject> SandTrapList = new List<GameObject>();
 
 
-    public void FindSandTrapsInTheScene() {
+    public void FindSandTraps() {
         foreach(GameObject GameObjectInTheScene in GameObject.FindObjectsOfType(typeof(GameObject)))
          {
              if(GameObjectInTheScene.GetComponent<SandTrap>() != null)
              SandTrapList.Add (GameObjectInTheScene);
-         }  
-
+         } 
+    
+    }
+    public void ClearList() {
+        SandTrapList.Clear();
     }       
 
 }

--- a/Assets/Scripts/SandTrapManager.cs.meta
+++ b/Assets/Scripts/SandTrapManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6415b5debd168aacba97475513a9357c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Singleton.cs
+++ b/Assets/Scripts/Singleton.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class Singleton<T> : MonoBehaviour where T: MonoBehaviour {
+    public static T Instance {
+        get {
+            InitializeIfNecessary();
+            return _instance;
+        }
+    }
+    static T _instance;
+
+    static void InitializeIfNecessary () {
+        if (_instance == null) {
+            _instance = Object.FindObjectOfType<T>();
+        }
+    }
+
+    void Awake () {
+        if (_instance != null && _instance != this) {
+            Destroy(this);
+            return;
+        }
+        InitializeIfNecessary();
+    }
+
+    void OnDestroy () {
+        _instance = null;
+    }
+}

--- a/Assets/Scripts/Singleton.cs.meta
+++ b/Assets/Scripts/Singleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf993ef975e1406dfb9a546b53166638
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION

### What's New

Se ha creado el Script "SandTrap Manager Editor"  con lo que se ha añadido 3 opciones al SandTrap Manager para poder ser usadas en modo edición.

- Mover las trampas.
- Crear nuevas trampas.
- Eliminar las trampas.

### Known Problems

En la opción de "mover trampas" también se puede mover el Sand Trap Manager y aveces resulta molesto.

Puedes apretar multiples botones del SandTrap Manager al mismo tiempo, esto tambien podría resultar molesto en algunas ocasiones.

### Testing

Entrar a la escena "Sand trap test" e interactuar con el GameObject "SandTrap Manager".

### Setting Up

Hacer el set up básico de un nivel y añadir el Prefab "SandTrap Manager".